### PR TITLE
Dynamic end date for crime map

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import TimeSlider from '@/components/TimeSlider'
 import { useSidebarStats } from '@/hooks/useSidebarStats'
 import { useIncidents } from '@/hooks/useIncidents'
 import { useIsMobile } from '@/components/ui/use-mobile'
+import { getDatasetEndDate } from '@/lib/utils'
 
 const Map = dynamic(() => import('@/components/Map'), {
   loading: () => <Skeleton className="h-[calc(100vh-8rem)] w-full" />,
@@ -54,7 +55,9 @@ export default function Home() {
       <main className="flex min-h-screen">
         <Sidebar />
         <div className="hidden md:flex flex-1  flex-col p-4 h-screen overflow-hidden">
-          <h1 className="text-2xl font-bold mb-4 text-center">Police Department Incident Reports (2018-2025)</h1>
+          <h1 className="text-2xl font-bold mb-4 text-center">
+            Police Department Incident Reports (2018-{getDatasetEndDate().getFullYear()})
+          </h1>
           <div className="relative flex-1 mb-4">
             <MapComponent />
           </div>

--- a/components/CrimeCharts.tsx
+++ b/components/CrimeCharts.tsx
@@ -6,6 +6,7 @@ import { useAllIncidents } from "@/hooks/useAllIncidents"
 import { useTime } from "@/contexts/TimeContext"
 import { useMemo } from "react"
 import { START_DATE } from "@/components/TimeSlider"
+import { getDatasetEndDate } from "@/lib/utils"
 
 import {
   Card,
@@ -42,7 +43,7 @@ export default function CrimeCharts() {
 
     const yearData: { [year: string]: number } = {}
     const startYear = 2018
-    const endYear = 2025
+    const endYear = getDatasetEndDate().getFullYear()
     
     // Initialize years
     for (let year = startYear; year <= endYear; year++) {
@@ -156,7 +157,9 @@ export default function CrimeCharts() {
       <Card>
         <CardHeader>
           <CardTitle>Monthly Crime Distribution</CardTitle>
-          <CardDescription>Bar chart showing criminal incidents by month (2018-2025)</CardDescription>
+          <CardDescription>
+            Bar chart showing criminal incidents by month (2018-{getDatasetEndDate().getFullYear()})
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <ChartContainer config={chartConfig}>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis, ReferenceLine } from "recharts"
 import { useTime } from '@/contexts/TimeContext'
 import { START_DATE } from '@/components/TimeSlider'
+import { getDatasetEndDate } from '@/lib/utils'
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
   ChartConfig,
@@ -105,7 +106,9 @@ export default function Sidebar() {
             <Card>
               <CardHeader className="pb-2">
                 <CardTitle>Monthly Distribution</CardTitle>
-                <CardDescription>Incidents by month (2018-2025)</CardDescription>
+                <CardDescription>
+                  Incidents by month (2018-{getDatasetEndDate().getFullYear()})
+                </CardDescription>
               </CardHeader>
               <CardContent>
                 <ChartContainer config={chartConfig}>

--- a/components/TimeSlider.tsx
+++ b/components/TimeSlider.tsx
@@ -5,9 +5,10 @@ import { Label } from "@/components/ui/label"
 import { useTime } from "@/contexts/TimeContext"
 import { useState, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
+import { getDatasetEndDate } from "@/lib/utils"
 
 export const START_DATE = new Date('2018-01-01')
-export const END_DATE = new Date('2025-01-07')
+export const END_DATE = getDatasetEndDate()
 export const TOTAL_WEEKS = Math.floor((END_DATE.getTime() - START_DATE.getTime()) / (7 * 24 * 60 * 60 * 1000))
 
 const SPEED_STORAGE_KEY = 'sf-crime-map:playback-speed'

--- a/hooks/useIncidents.ts
+++ b/hooks/useIncidents.ts
@@ -1,6 +1,7 @@
 import { useTime } from '@/contexts/TimeContext'
 import { START_DATE } from '@/components/TimeSlider'
 import { useMemo } from 'react'
+import { getDatasetEndDate, formatDateISO } from '@/lib/utils'
 import { useMotherDuckClientState } from '@/lib/motherduck/context/motherduckClientContext'
 import { Incident } from '@/types/incidents'
 import { useState, useEffect } from 'react'
@@ -43,21 +44,22 @@ Neighborhoods,
 "Current Supervisor Districts",
 "Current Police Districts"
 */
+const END_DATE_SQL = formatDateISO(getDatasetEndDate())
 const SQL_QUERY = `
-SELECT 
+SELECT
   "Incident Datetime" as incident_datetime,
   "Incident Category" as incident_category,
   "Incident Description" as incident_description,
   Latitude as latitude,
   Longitude as longitude
-FROM 
+FROM
   sf_crime_stats.data
-WHERE 
-  Latitude IS NOT NULL 
+WHERE
+  Latitude IS NOT NULL
   AND Longitude IS NOT NULL
   AND "Incident Category" != 'Non-Criminal'
   AND "Incident Datetime" >= '2018-01-01'
-  AND "Incident Datetime" <= '2025-12-31'
+  AND "Incident Datetime" <= '${END_DATE_SQL}'
 ORDER BY "Incident Datetime" DESC;
 `
 

--- a/hooks/useSidebarStats.ts
+++ b/hooks/useSidebarStats.ts
@@ -1,5 +1,6 @@
 import { useMotherDuckClientState } from '@/lib/motherduck/context/motherduckClientContext'
 import { useState, useEffect } from 'react'
+import { getDatasetEndDate, formatDateISO } from '@/lib/utils'
 /*
 all columns
 "Incident Datetime",
@@ -48,6 +49,7 @@ export interface MonthlyStats {
   malicious_mischief: number
 }
 
+const END_DATE_SQL = formatDateISO(getDatasetEndDate())
 const SQL_QUERY = `
 WITH parsed_dates AS (
   SELECT 
@@ -62,7 +64,7 @@ WITH parsed_dates AS (
     sf_crime_stats.data
   WHERE 
     "Incident Datetime" >= '2018-01-01'
-    AND "Incident Datetime" <= '2025-12-31'
+    AND "Incident Datetime" <= '${END_DATE_SQL}'
     AND "Incident Category" != 'Non-Criminal'
   GROUP BY 
     "Incident Datetime",

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,19 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Return the date representing the end of the available dataset.
+ * This is set to one week prior to the current date to allow for
+ * a lag between real time and data updates.
+ */
+export function getDatasetEndDate(lagDays = 7): Date {
+  const date = new Date()
+  date.setDate(date.getDate() - lagDays)
+  return date
+}
+
+/** Convenience helper to format a Date as YYYY-MM-DD */
+export function formatDateISO(date: Date): string {
+  return date.toISOString().split('T')[0]
+}


### PR DESCRIPTION
## Summary
- provide helper functions to determine dataset end date
- update TimeSlider to use dynamic end date
- fetch incidents and sidebar stats up to current data minus a week
- update charts and UI text to show correct end year

## Testing
- `npm run lint` *(fails: `next` not found)*